### PR TITLE
readme: don't require colcon mixin

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ rosdep install \
 # build the package (including any dependencies). To build the entire
 # workspace, simply run 'colcon build'
 colcon build \
-  --mixin release \
-  --packages-up-to motoros2_client_interface_dependencies
+  --packages-up-to motoros2_client_interface_dependencies \
+  --cmake-args -DCMAKE_BUILD_TYPE=Release
 ```
 
 If there were no warnings or errors, the workspace should now be activated using:


### PR DESCRIPTION
As per title.

Should avoid confusion as in #15, while essentially doing the same thing.
