### PR TITLE
Specify commit hash for `industrial_msgs`

### DIFF
--- a/source_deps.repos
+++ b/source_deps.repos
@@ -6,4 +6,5 @@ repositories:
   ros-industrial/industrial_core_ros2_msgs_only:
     type: git
     url: https://github.com/ros-industrial/industrial_core.git
+    # branch name: ros2_msgs_only
     version: d547cdcfdaf3bc0d46325215b8219b0a190c8e6c

--- a/source_deps.repos
+++ b/source_deps.repos
@@ -6,4 +6,4 @@ repositories:
   ros-industrial/industrial_core_ros2_msgs_only:
     type: git
     url: https://github.com/ros-industrial/industrial_core.git
-    version: ros2_msgs_only
+    version: d547cdcfdaf3bc0d46325215b8219b0a190c8e6c


### PR DESCRIPTION
This PR specifies a commit hash for the `industrial_msgs` package instead of a branch name to avoid downstream effects in the case that a breaking change gets pushed to the `ros2_msgs_only` branch at some point in the future.